### PR TITLE
Execute gradlew test in github workflow using xvfb-run

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle
-      run: ./gradlew test
+      run: xvfb-run ./gradlew test
     - name: Style Code Report
       if: failure()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
The xvfb-run tool is an X server that can run on machines with no display hardware and no physical input devices. It emulates a dumb framebuffer using virtual memory.

This is needed in the VM running github actions so when unit tests run code for UI components do not fail with error below
```
java.awt.HeadlessException:
    No X11 DISPLAY variable was set
```

This does not affect local execution in windows machines where UI is enabled to run